### PR TITLE
Added Default output name for FindMitoReference

### DIFF
--- a/findMitoReference.py
+++ b/findMitoReference.py
@@ -85,7 +85,8 @@ if __name__ == '__main__':
     parser = ArgumentParser()
     parser.add_argument('--species', required=True, help='latin name')
     parser.add_argument('--email', required=True)
-    parser.add_argument('--outfolder', nargs='?', default="")
+    parser.add_argument('--outfolder', nargs='?', default="closestMitoReference", \
+                        help='Folder to house the downloaded reference. Default: closestMitoReference')
     parser.add_argument('-s', action='store_true', help='search for an exact species')
     parser.add_argument('--min_length', nargs='?', type=int  , default=0, \
                                   help='minimal appropriate length')


### PR DESCRIPTION
findMitoReference fails without an informative error, as the --output option is obligatory, but not flagged as such. I have added a Default Name for the folder that houses the downloaded reference ('closestMitoReference').