### PR TITLE
Declare variables outside try scope to fix UnboundLocalError.

### DIFF
--- a/mitohifi.py
+++ b/mitohifi.py
@@ -133,7 +133,9 @@ def main():
         logging.info(" ".join(hifiasm_cmd))
         with open("hifiasm.log", "w") as hifiasm_log_f:
             subprocess.run(hifiasm_cmd, stderr=subprocess.STDOUT, stdout=hifiasm_log_f)       
-        
+
+        f1 = None
+        f2 = None
         try:
             f1 = open("gbk.HiFiMapped.bam.filtered.assembled.p_ctg.gfa")
             f2 = open("gbk.HiFiMapped.bam.filtered.assembled.a_ctg.gfa")
@@ -141,8 +143,10 @@ def main():
             sys.exit("""No gbk.HiFiMapped.bam.filtered.assembled.[a/p]_ctg.gfa file(s).
             An error may have occurred when assembling reads with HiFiasm.""")
         finally:
-            f1.close()
-            f2.close()
+            if f1:
+                f1.close()
+            if f2:
+                f2.close()
 
         gfa2fa_script = os.path.join(os.path.dirname(os.path.realpath(__file__)),"gfa2fa") # gets path to gfa2fa script
         


### PR DESCRIPTION
This issue comes from the https://github.com/marcelauliano/MitoHiFi/issues/26 .

Currently, if the `hifiasm` doesn't create the `gbk.HiFiMapped.bam.filtered.assembled.p_ctg.gfa` file, and raises the `FileNotFoundError`, the `f1.close()` and `f2.close()` in the `finally` scope are still executed. In the case, the `f1` and `f2` are not declared, and the `UnboundLocalError` happens. This commit suppresses this error.

The current state is below.

```
2022-10-11 16:31:54 [INFO] hifiasm --primary -t 4 -f 0 -o gbk.HiFiMapped.bam.filtered.assembled gbk.HiFiMapped.bam.filtered.fasta
Traceback (most recent call last):
  File "/bin/MitoHiFi/mitohifi.py", line 139, in main
    f1 = open("gbk.HiFiMapped.bam.filtered.assembled.p_ctg.gfa")
FileNotFoundError: [Errno 2] No such file or directory: 'gbk.HiFiMapped.bam.filtered.assembled.p_ctg.gfa'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/bin/MitoHiFi/mitohifi.py", line 143, in main
    An error may have occurred when assembling reads with HiFiasm.""")
SystemExit: No gbk.HiFiMapped.bam.filtered.assembled.[a/p]_ctg.gfa file(s).
            An error may have occurred when assembling reads with HiFiasm.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/bin/MitoHiFi/mitohifi.py", line 377, in <module>
    main()
  File "/bin/MitoHiFi/mitohifi.py", line 145, in main
    f1.close()
UnboundLocalError: local variable 'f1' referenced before assignment
```

After this PR, the state is below, suppressing the `UnboundLocalError` message.

```
root@0a47724a2c2d:/bin/MitoHiFi# mitohifi.py -r /data/generated_asm.bp.r_utg.fa -f /data/ON980565.1.fasta -g /data/ON980565.1.gb -t 4 -o 2
2022-10-18 13:17:54 [INFO] Welcome to MitoHifi v2. Starting pipeline...
2022-10-18 13:17:54 [INFO] Length of related mitogenome is: 16574 bp
2022-10-18 13:17:54 [INFO] Number of genes on related mitogenome: 37
2022-10-18 13:17:54 [INFO] Running MitoHifi pipeline in reads mode...
2022-10-18 13:17:54 [INFO] 1. First we map your Pacbio HiFi reads to the close-related mitogenome
2022-10-18 13:17:54 [INFO] minimap2 -t 4 --secondary=no -ax map-pb /data/ON980565.1.fasta /data/generated_asm.bp.r_utg.fa | samtools view -@ 4 -S -b -F4 -F 0x800 > reads.HiFiMapped.bam
2022-10-18 13:17:54 [INFO] 2. Now we filter out any mapped reads that are larger than the reference mitogenome to avoid NUMTS
2022-10-18 13:17:54 [INFO] 2.1 First we convert the mapped reads from BAM to FASTA format:
2022-10-18 13:17:54 [INFO] samtools fasta reads.HiFiMapped.bam > gbk.HiFiMapped.bam.fasta
2022-10-18 13:17:54 [INFO] Total number of mapped reads: 0
2022-10-18 13:17:54 [INFO] 2.2 Then we filter reads that are larger than 16574 bp
2022-10-18 13:17:54 [INFO] Number of filtered reads: 0
2022-10-18 13:17:54 [INFO] 3. Now let's run hifiasm to assemble the mapped and filtered reads!
2022-10-18 13:17:54 [INFO] hifiasm --primary -t 4 -f 0 -o gbk.HiFiMapped.bam.filtered.assembled gbk.HiFiMapped.bam.filtered.fasta
No gbk.HiFiMapped.bam.filtered.assembled.[a/p]_ctg.gfa file(s).
            An error may have occurred when assembling reads with HiFiasm.
```

In the `mitohifi.py`, I see other parts like this pattern. The solution is like the below as this PR. It is great if you fix the other parts.

```
f = None # <= add this line.
try:
    f = open("<file>")
except FileNotFoundError:
    sys.exit("""<message>""")
finally:
    if f:
        f.close()
```

