### PR TITLE
update getGenesList.py to support `gb` files without `gene` feature

### DIFF
--- a/src/getGenesList.py
+++ b/src/getGenesList.py
@@ -22,7 +22,10 @@ def get_genes_list(in_annotation, format="genbank"):
                     genes.append(feat.qualifiers['product'][0])
                     #genes.append([feat.qualifiers['product'], feat.location])
                 elif feat.type == "CDS":
-                    genes.append(feat.qualifiers['gene'][0])
+                    genes.append(feat.qualifiers['product'][0])
+                    name_replacement = {"NADH dehydrogenase subunit 6": "ND6", "NADH dehydrogenase subunit 4L": "ND4L", "12S ribosomal RNA": "s-rRNA", "NADH dehydrogenase subunit 1": "ND1", "ATP synthase F0 subunit 6": "ATP6", "NADH dehydrogenase subunit 2": "ND2", "cytochrome b": "CYTB", "cytochrome c oxidase subunit III": "COIII", "NADH dehydrogenase subunit 4": "ND4", "cytochrome c oxidase subunit I": "COI", "cytochrome c oxidase subunit II": "COII", "16S ribosomal RNA": "l-rRNA", "NADH dehydrogenase subunit 3": "ND3", "NADH dehydrogenase subunit 5": "ND5"}
+                    genes = [gene if gene not in name_replacement else name_replacement[gene] for gene in genes]
+                    #genes.append(feat.qualifiers['gene'][0])
                     #genes.append([feat.qualifiers['gene'], feat.location])
     
     elif format == "gff":


### PR DESCRIPTION
Hello!! Sometimes `getGenesList.py` fails because the reference MT does not use `gene` as a feature, instead it uses `product`, see issues https://github.com/marcelauliano/MitoHiFi/issues/81 and https://github.com/marcelauliano/MitoHiFi/issues/49 .

This edit changes the script to use `product`, and includes a dictionary to replace the value if the long name from the `product` value will not work downstream. Feel free to remove the replacement (lines 26-27) if the long name works fine.

<img width="1090" alt="image" src="https://github.com/marcelauliano/MitoHiFi/assets/48773001/5fc486a0-e315-49fe-8599-868883ed1851">

Tested it with the problematic `gb` file mentioned in issue 81 and it returns the list as above.

I hope this is helpful!!

Best,
Linelle
