### PR TITLE
Define frameshift regex as raw string to prevent Syntax Warnings

### DIFF
--- a/src/findFrameShifts.py
+++ b/src/findFrameShifts.py
@@ -18,7 +18,7 @@ def find_frameshifts(in_gb):
             if feature.type == 'CDS':
                 gene_name = feature.qualifiers['gene'][0]
                 gene_amino = feature.qualifiers['translation'][0]
-                if re.search("[A-Z]\*[A-Z]", gene_amino):
+                if re.search(r"[A-Z]\*[A-Z]", gene_amino):
                     print("Gene {} contains frameshift".format(gene_name))
                     frameshift_genes.add(gene_name)
     return frameshift_genes 
@@ -31,7 +31,7 @@ def find_frameshifts_mitos(in_proteins_fasta):
         seq = str(record.seq)
         description = record.description
         gene_name = description.split(";")[-1].strip()
-        if re.search("[A-Z]\*[A-Z]", seq):
+        if re.search(r"[A-Z]\*[A-Z]", seq):
             print("Gene {} contains frameshift".format(gene_name))
             frameshift_genes.append(gene_name)
     return frameshift_genes 


### PR DESCRIPTION
In more recent versions of Python 3, when the string "\*" is encountered, it raises a SyntaxWarning because it is not a valid escape sequence. To avoid that warning, we can define the string as raw by inserting an "r" before it. This way, Python does not attempt to interpret "\*" as an escape sequence, and the warning is no longer triggered. Important: The previous version of the code was working correctly because when Python cannot find "\*" in the escape sequence dictionary, it treats it as a raw string. This is the desired behavior but had the inconvenience of displaying the warning message.