### PR TITLE
Conda ci

### DIFF
--- a/.github/workflows/github-actions-build-base.yml
+++ b/.github/workflows/github-actions-build-base.yml
@@ -1,10 +1,10 @@
 name: Build and Publish MitoHiFi base
 
-on:  workflow_dispatch
-  #  push:
-  #    branches:
-  #    - 'master'
-  
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'b*'
 
 env:
   REGISTRY: ghcr.io
@@ -41,7 +41,8 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
-            type=semver,pattern={{version}}
+            type=ref,event=tag
+
       - name: Build image and push to GitHub Container Registry
         uses: docker/build-push-action@v2
         id: build-and-push

--- a/.github/workflows/github-actions-build-base.yml
+++ b/.github/workflows/github-actions-build-base.yml
@@ -44,7 +44,7 @@ jobs:
             type=ref,event=tag
 
       - name: Build image and push to GitHub Container Registry
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         id: build-and-push
         with:
           context: ./environment/base

--- a/.github/workflows/github-actions-build-base.yml
+++ b/.github/workflows/github-actions-build-base.yml
@@ -8,8 +8,7 @@ on:  workflow_dispatch
 
 env:
   REGISTRY: ghcr.io
-  ORGANISATION: marcelauliano
-  IMAGE_NAME: MitoHiFi-base
+  IMAGE_NAME: ${{ github.repository }}-base
 
 permissions:
   contents: write
@@ -39,7 +38,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.ORGANISATION }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}

--- a/.github/workflows/github-actions-build-code.yml
+++ b/.github/workflows/github-actions-build-code.yml
@@ -52,8 +52,8 @@ jobs:
       - name: Set output
         id: docker_image
         run: |
-          echo "docker_image=${{ env.REGISTRY }}/${env.IMAGE_NAME,,}" >> $GITHUB_OUTPUT
- 
+          docker_image="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          echo "docker_image=${docker_image,,}" >> $GITHUB_OUTPUT
       - name: Build image and push to GitHub Container Registry
         uses: docker/build-push-action@v2
         id: build-and-push

--- a/.github/workflows/github-actions-build-code.yml
+++ b/.github/workflows/github-actions-build-code.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set output
         id: docker_image
         run: |
-          echo "docker_image=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" >> $GITHUB_OUTPUT
+          echo "docker_image=${{ env.REGISTRY }}/${env.IMAGE_NAME,,}" >> $GITHUB_OUTPUT
  
       - name: Build image and push to GitHub Container Registry
         uses: docker/build-push-action@v2

--- a/.github/workflows/github-actions-build-code.yml
+++ b/.github/workflows/github-actions-build-code.yml
@@ -26,7 +26,7 @@ jobs:
 
     outputs:
       DOCKER_IMAGE: ${{ steps.docker_image.outputs.docker_image }}
-      DOCKER_IMAGE_DIGEST: ${{ steps.docker_image.outputs.docker_image_digest }}
+      DOCKER_IMAGE_DIGEST: ${{ steps.image_digest.outputs.docker_image_digest }}
 
     # steps to perform in job
     steps:
@@ -64,7 +64,7 @@ jobs:
           push: true
 
       - name: Image digest
-        id: image-digest
+        id: image_digest
         run: |
           echo ${{ steps.build-and-push.outputs.digest }}
           echo "docker_image_digest=${{ steps.build-and-push.outputs.digest }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/github-actions-build-code.yml
+++ b/.github/workflows/github-actions-build-code.yml
@@ -26,6 +26,7 @@ jobs:
 
     outputs:
       DOCKER_IMAGE: ${{ steps.docker_image.outputs.docker_image }}
+      DOCKER_IMAGE_DIGEST: ${{ steps.docker_image.outputs.docker_image_digest }}
 
     # steps to perform in job
     steps:
@@ -63,11 +64,14 @@ jobs:
           push: true
 
       - name: Image digest
-        run: echo ${{ steps.build-and-push.outputs.digest }}
+        id: image-digest
+        run: |
+          echo ${{ steps.build-and-push.outputs.digest }}
+          echo "docker_image_digest=${{ steps.build-and-push.outputs.digest }}" >> $GITHUB_OUTPUT
 
   integration-tests:
     needs: build-and-push-docker-image
     uses: ./.github/workflows/github-actions-integration-test.yml
     with:
       docker_image: ${{ needs.build-and-push-docker-image.outputs.DOCKER_IMAGE }}
-      digest: ${{ needs.build-and-push-docker-image.outputs.digest }}
+      digest: ${{ needs.build-and-push-docker-image.outputs.DOCKER_IMAGE_DIGEST }}

--- a/.github/workflows/github-actions-build-code.yml
+++ b/.github/workflows/github-actions-build-code.yml
@@ -2,9 +2,9 @@ name: Build and Publish MitoHiFi code
 
 on:
   workflow_dispatch:
-  release:
-    types: [published]
   push:
+    tags:
+    - 'v*'
     branches:
     - 'master'
 

--- a/.github/workflows/github-actions-build-code.yml
+++ b/.github/workflows/github-actions-build-code.yml
@@ -58,7 +58,8 @@ jobs:
         uses: docker/build-push-action@v6
         id: build-and-push
         with:
-          context: ./environment/code
+          context: .
+          file: ./environment/code/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true

--- a/.github/workflows/github-actions-build-code.yml
+++ b/.github/workflows/github-actions-build-code.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   release:
     types: [published]
+  push:
+    branches:
+    - 'master'
 
 env:
   REGISTRY: ghcr.io
@@ -20,6 +23,9 @@ jobs:
     name: Build Docker image and push to repositories
     # run only when code is compiling and tests are passing
     runs-on: ubuntu-latest
+
+    outputs:
+      DOCKER_IMAGE: ${{ steps.docker_image.outputs.docker_image }}
 
     # steps to perform in job
     steps:
@@ -41,6 +47,11 @@ jobs:
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
+
+      - name: Set output
+        id: docker_image
+        run: |
+          echo "docker_image=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" >> $GITHUB_OUTPUT
  
       - name: Build image and push to GitHub Container Registry
         uses: docker/build-push-action@v2
@@ -53,3 +64,10 @@ jobs:
 
       - name: Image digest
         run: echo ${{ steps.build-and-push.outputs.digest }}
+
+  integration-tests:
+    needs: build-and-push-docker-image
+    uses: ./.github/workflows/github-actions-integration-test.yml
+    with:
+      docker_image: ${{ needs.build-and-push-docker-image.outputs.DOCKER_IMAGE }}
+      digest: ${{ needs.build-and-push-docker-image.outputs.digest }}

--- a/.github/workflows/github-actions-build-code.yml
+++ b/.github/workflows/github-actions-build-code.yml
@@ -55,7 +55,7 @@ jobs:
           docker_image="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
           echo "docker_image=${docker_image,,}" >> $GITHUB_OUTPUT
       - name: Build image and push to GitHub Container Registry
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         id: build-and-push
         with:
           context: ./environment/code

--- a/.github/workflows/github-actions-build-code.yml
+++ b/.github/workflows/github-actions-build-code.yml
@@ -1,16 +1,13 @@
 name: Build and Publish MitoHiFi code
 
-on:  workflow_dispatch
-  # push:
-  #   branches:
-  #   - 'master'
-
-
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
 
 env:
   REGISTRY: ghcr.io
-  ORGANISATION: marcelauliano
-  IMAGE_NAME: MitoHiFi
+  IMAGE_NAME: ${{ github.repository }}
 
 permissions:
   contents: write
@@ -40,10 +37,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.ORGANISATION }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
+ 
       - name: Build image and push to GitHub Container Registry
         uses: docker/build-push-action@v2
         id: build-and-push

--- a/.github/workflows/github-actions-integration-test.yml
+++ b/.github/workflows/github-actions-integration-test.yml
@@ -1,9 +1,14 @@
 name: MitoHiFi Integration Test
 
-on:  # workflow_dispatch
-  push:
-    branches:
-    - 'master'
+on:
+  workflow_call:
+    inputs:
+      docker_image:
+        required: true
+        type: string
+      digest:
+        required: true
+        type: string
   
 jobs:
   integration_test:
@@ -16,7 +21,7 @@ jobs:
       - name: Run integration test_contigs with Docker
         run: |
           docker run --name test_contigs \
-          ghcr.io/marcelauliano/mitohifi:master \
+          ${{ inputs.docker_image}}@${{ inputs.digest }} \
             mitohifi.py \
             -c /opt/MitoHiFi/tests/ilPhaBuce1_contig.fa \
             -f /opt/MitoHiFi/tests/NC_016067.1.fasta \
@@ -31,7 +36,7 @@ jobs:
       - name: Run integration test_reads with Docker
         run: |
           docker run --name test_reads \
-          ghcr.io/marcelauliano/mitohifi:master \
+          ${{ inputs.docker_image}}@${{ inputs.digest }} \
             mitohifi.py \
             -r /opt/MitoHiFi/tests/ilDeiPorc1.reads.100.fa \
             -f /opt/MitoHiFi/tests/MW539688.1.fasta \
@@ -43,6 +48,3 @@ jobs:
         run: |
           docker cp test_reads:/tmp/final_mitogenome.fasta ./
           cmp tests/ilDeiPorc1.final_mitogenome.fasta final_mitogenome.fasta && echo 'SUCCESS READS & MITOS'
-
-          
-

--- a/environment/base/Dockerfile
+++ b/environment/base/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get -qq -y update \
     wget \
     vim \
     && rm -rf /var/lib/apt/lists/*
-    
+# this will install python3.6.9 and python2.7.17
+# and pip3 9.0.1  under /usr/bin/  
 
 WORKDIR /opt
 
@@ -39,12 +40,16 @@ RUN curl -L https://github.com/chhylp123/hifiasm/archive/refs/tags/0.16.1.tar.gz
     && wget -P /usr/local/src https://bootstrap.pypa.io/pip/2.7/get-pip.py \
     && python2 /usr/local/src/get-pip.py \
     && python2 -m pip --no-cache-dir install biopython==1.70
+# This will install pip2 20.3.4 under /usr/local/bin
+# and biopython 1.70 under /usr/local/lib/python2.7/dist-packages
 
 # /opt/MitoFinder
 RUN git clone https://github.com/RemiAllio/MitoFinder.git \
     && cd MitoFinder \
     && ./install.sh \
     && sed -i 's/\/usr\/bin\/python/\/usr\/bin\/env python/' mitofinder
+# This step will change the shebang line in mitofinder to use /usr/bin/env python
+# The original shebang line is #!/usr/bin/python2.7 and no effect in this stage
 RUN chmod -R 755 /opt/MitoFinder
 
 RUN git clone https://github.com/weizhongli/cdhit.git && \
@@ -55,6 +60,8 @@ RUN mkdir -p /opt/wrappers
 
 COPY mitos_wrapper.sh /opt/wrappers/runmitos.py
 COPY mitofinder_wrapper.sh /opt/wrappers/mitofinder
+# This will overwrite the original two scripts
+# and change the python installed two different conda environments which are not created yet
 
 RUN chmod -R 755 /opt/wrappers
 
@@ -66,7 +73,11 @@ RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/downloa
 
 
 RUN $CONDA_DIR/bin/conda create -n mitos_env -c bioconda -c conda-forge mitos=2.1.0 "r-base>4"
+# this will create a conda environment named mitos_env
+# with python3.12.7 and r-base 4.1.1, and biopython 1.76
 RUN $CONDA_DIR/bin/conda create -n mitofinder_env python=2.7
+# this will create a conda environment named mitofinder_env
+# with python2.7.15
 
 RUN $CONDA_DIR/bin/conda clean -a
 
@@ -79,6 +90,9 @@ RUN curl -L https://zenodo.org/record/4284483/files/refseq89m.tar.bz2?download=1
 
 WORKDIR /opt
 
+# this will install pip3 under /usr/local/bin
+# pip 21.3.1 from /usr/local/lib/python3.6/dist-packages/pip
+# which is different from the original /usr/bin/pip3 installed above
 RUN pip3 --no-cache-dir install --upgrade pip \
     && pip3 --no-cache-dir install biopython \
     pandas \
@@ -87,3 +101,5 @@ RUN pip3 --no-cache-dir install --upgrade pip \
     entrezpy \
     dna_features_viewer \
     bcbio-gff
+# this will install all packages under /usr/local/lib/python3.6/dist-packages
+# include biopython 1.79

--- a/environment/base/Dockerfile
+++ b/environment/base/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /opt
 
 # /opt/minimap2-2.24_x64-linux
 RUN curl -L https://github.com/lh3/minimap2/releases/download/v2.24/minimap2-2.24_x64-linux.tar.bz2 \
-    | tar -jxvf -
+    | tar -jxvf  - --no-same-owner
 
 # /opt/hifiasm-0.16.1
 RUN curl -L https://github.com/chhylp123/hifiasm/archive/refs/tags/0.16.1.tar.gz \

--- a/environment/base/Dockerfile
+++ b/environment/base/Dockerfile
@@ -60,12 +60,13 @@ RUN chmod -R 755 /opt/wrappers
 
 ARG CONDA_DIR=/opt/conda
 
-RUN wget -P /usr/local/src https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
-    && bash /usr/local/src/Miniconda3-latest-Linux-x86_64.sh -b -p $CONDA_DIR \
-    && $CONDA_DIR/bin/conda install -n base conda-libmamba-solver
+RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" \
+    && bash Miniforge3-$(uname)-$(uname -m).sh -bfp $CONDA_DIR \
+    && rm -rf Miniforge3-$(uname)-$(uname -m).sh
+
 
 RUN $CONDA_DIR/bin/conda create -n mitos_env -c bioconda -c conda-forge mitos=2.1.0 "r-base>4"
-RUN $CONDA_DIR/bin/conda create -n mitofinder_env --experimental-solver=libmamba python=2.7
+RUN $CONDA_DIR/bin/conda create -n mitofinder_env python=2.7
 
 RUN $CONDA_DIR/bin/conda clean -a
 

--- a/environment/base/Dockerfile
+++ b/environment/base/Dockerfile
@@ -3,7 +3,6 @@ FROM ubuntu:18.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -qq -y update \
-    && apt-get -qq -y update \
     && apt-get -qq -y install \
     autoconf \
     automake \

--- a/environment/base/Dockerfile
+++ b/environment/base/Dockerfile
@@ -99,7 +99,7 @@ RUN pip3 --no-cache-dir install --upgrade pip \
     Pillow \
     matplotlib \
     entrezpy \
-    dna_features_viewer \
+    dna_features_viewer==3.1.2 \
     bcbio-gff
 # this will install all packages under /usr/local/lib/python3.6/dist-packages
 # include biopython 1.79

--- a/environment/base/Dockerfile
+++ b/environment/base/Dockerfile
@@ -100,6 +100,6 @@ RUN pip3 --no-cache-dir install --upgrade pip \
     matplotlib \
     entrezpy \
     dna_features_viewer==3.1.2 \
-    bcbio-gff
+    bcbio-gff==0.7.0
 # this will install all packages under /usr/local/lib/python3.6/dist-packages
 # include biopython 1.79

--- a/environment/code/Dockerfile
+++ b/environment/code/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/marcelauliano/mitohifi-base:reviews
+FROM ghcr.io/gq1/mitohifi-base:b1.0
 
 WORKDIR /opt
 

--- a/environment/code/Dockerfile
+++ b/environment/code/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/gq1/mitohifi-base:b1.0.0
+FROM ghcr.io/gq1/mitohifi-base:b1.0.1
 
 COPY . /opt/MitoHiFi
 

--- a/environment/code/Dockerfile
+++ b/environment/code/Dockerfile
@@ -1,10 +1,10 @@
-FROM ghcr.io/gq1/mitohifi-base:b1.0
+FROM ghcr.io/gq1/mitohifi-base:b1.0.0
 
-WORKDIR /opt
+COPY . /opt/MitoHiFi
 
-# /opt/MitoHiFi
-RUN git clone https://github.com/marcelauliano/MitoHiFi.git \
-    && cd MitoHiFi/src \
+WORKDIR /opt/MitoHiFi
+
+RUN cd src \
     && chmod +x *.py \
     && sed -i '1i#!/usr/bin/env python3' mitohifi.py findFrameShifts.py fixContigHeaders.py \
     && sed -i '1 s/python\>/python3/' *.py \
@@ -16,4 +16,3 @@ WORKDIR /tmp
 ENV CONDA_DIR=/opt/conda
 
 ENV PATH=/opt/wrappers:/opt/cdhit/:/opt/hifiasm-0.16.1/:/opt/MitoHiFi/src/:/opt/MitoFinder/:/opt/minimap2-2.24_x64-linux/:${PATH}
-#create docker in main branch now

--- a/environment/code/Dockerfile
+++ b/environment/code/Dockerfile
@@ -15,5 +15,5 @@ WORKDIR /tmp
 
 ENV CONDA_DIR=/opt/conda
 
-ENV PATH /opt/wrappers:/opt/cdhit/:/opt/hifiasm-0.16.1/:/opt/MitoHiFi/src/:/opt/MitoFinder/:/opt/minimap2-2.24_x64-linux/:${PATH}
+ENV PATH=/opt/wrappers:/opt/cdhit/:/opt/hifiasm-0.16.1/:/opt/MitoHiFi/src/:/opt/MitoFinder/:/opt/minimap2-2.24_x64-linux/:${PATH}
 #create docker in main branch now

--- a/environment/code/Dockerfile
+++ b/environment/code/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/gq1/mitohifi-base:b1.0.1
+FROM ghcr.io/gq1/mitohifi-base:b1.0.2
 
 COPY . /opt/MitoHiFi
 


### PR DESCRIPTION
This will replace my previous two PRs to update conda and ci, both of your tests can pass now.

The main problem is the default version being used when install `Python`, `BioPython`,` dna_features_viewer` and `bcbio-gff` which under a old version `Ubuntu` 18.04.
