### PR TITLE
Making MitoHiFi ONT compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 
 I tested this version with a singularity container and that worked. I made sure it is running with the hifiasm v0.25.0. I also had to make sure that for the ONT version minimap2 results would be transformed into fastq rather than fasta.
 I did have to make some adjustments in the docker files in order to create the docker containers from which I made the singularity container. Therefore, here some installation instructions:
-'''
+```
 git clone https://github.com/pwkooij/MitoHiFi/
 cd MitoHiFi/environment/base
 docker build -t mitohifi-base .
 cd ../..
 docker build -t mitohifi -f environment/code/Dockerfile .
 singularity build mitohifi_ont_version.sif docker-daemon://mitohifi:latest
-'''
+```
 Now the 'mitohifi.py' should work within the singularity container. By adding the '--ont' tag it should run both minimap2 and hifiasm with the ONT settings.
 
 Hope this helps for those of us working with ONT!

--- a/README.md
+++ b/README.md
@@ -133,14 +133,15 @@ python MitoHiFi/src/mitohifi.py -h
 ```
 usage: MitoHiFi [-h] (-r <reads>.fasta | -c <contigs>.fasta) -f
                 <relatedMito>.fasta -g <relatedMito>.gbk -t <THREADS> [-d]
-                [-a {animal,plant,fungi}] [-p <PERC>] [-m <BLOOM FILTER>]
+                [--ont] [-a {animal,plant,fungi}] [-p <PERC>]
+                [-m <BLOOM FILTER>] [--min-contig-len MIN_CONTIG_LEN]
                 [--max-read-len MAX_READ_LEN] [--mitos]
                 [--circular-size CIRCULAR_SIZE]
                 [--circular-offset CIRCULAR_OFFSET] [-winSize WINSIZE]
                 [-covMap COVMAP] [-v] [-o <GENETIC CODE>]
 
 required arguments:
-  -r <reads>.fasta      -r: Pacbio Hifi Reads from your species
+  -r <reads>.fasta      -r: Pacbio Hifi or ONT Reads from your species
   -c <contigs>.fasta    -c: Assembled fasta contigs/scaffolds to be searched
                         to find mitogenome
   -f <relatedMito>.fasta
@@ -152,12 +153,17 @@ required arguments:
 
 optional arguments:
   -d                    -d: debug mode to output additional info on log
+  --ont                 Use Oxford Nanopore (ONT) settings instead of PacBio
+                        HiFi for minimap2 and hifiasm
   -a {animal,plant,fungi}
                         -a: Choose between animal (default) or plant
   -p <PERC>             -p: Percentage of query in the blast match with close-
                         related mito
   -m <BLOOM FILTER>     -m: Number of bits for HiFiasm bloom filter [it maps
                         to -f in HiFiasm] (default = 0)
+  --min-contig-len MIN_CONTIG_LEN
+                        Minimum contig length to retain after hifiasm assembly
+                        (default = 0)
   --max-read-len MAX_READ_LEN
                         Maximum lenght of read relative to related mito
                         (default = 1.0x related mito length)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
 # MitoHiFi 
+------ This is an updated version to allow ONT settings ------
+
+I tested this version with a singularity container and that worked. I made sure it is running with the hifiasm v0.25.0. I also had to make sure that for the ONT version minimap2 results would be transformed into fastq rather than fasta.
+I did have to make some adjustments in the docker files in order to create the docker containers from which I made the singularity container. Therefore, here some installation instructions:
+'''
+git clone https://github.com/pwkooij/MitoHiFi/
+cd MitoHiFi/environment/base
+docker build -t mitohifi-base .
+cd ../..
+docker build -t mitohifi -f environment/code/Dockerfile .
+singularity build mitohifi_ont_version.sif docker-daemon://mitohifi:latest
+'''
+Now the 'mitohifi.py' should work within the singularity container. By adding the '--ont' tag it should run both minimap2 and hifiasm with the ONT settings.
+
+Hope this helps for those of us working with ONT!
 
 ------ This is v3.2.2 ------
 

--- a/environment/base/Dockerfile
+++ b/environment/base/Dockerfile
@@ -33,9 +33,9 @@ RUN curl -L https://github.com/lh3/minimap2/releases/download/v2.24/minimap2-2.2
     | tar -jxvf  - --no-same-owner
 
 # /opt/hifiasm-0.16.1
-RUN curl -L https://github.com/chhylp123/hifiasm/archive/refs/tags/0.16.1.tar.gz \
+RUN curl -L https://github.com/chhylp123/hifiasm/archive/refs/tags/0.25.0.tar.gz \
     | tar -xzvf - \
-    && cd hifiasm-0.16.1 \
+    && cd hifiasm-0.25.0 \
     && make \
     && wget -P /usr/local/src https://bootstrap.pypa.io/pip/2.7/get-pip.py \
     && python2 /usr/local/src/get-pip.py \

--- a/environment/code/Dockerfile
+++ b/environment/code/Dockerfile
@@ -15,4 +15,4 @@ WORKDIR /tmp
 
 ENV CONDA_DIR=/opt/conda
 
-ENV PATH=/opt/wrappers:/opt/cdhit/:/opt/hifiasm-0.16.1/:/opt/MitoHiFi/src/:/opt/MitoFinder/:/opt/minimap2-2.24_x64-linux/:${PATH}
+ENV PATH=/opt/wrappers:/opt/cdhit/:/opt/hifiasm-0.25.0/:/opt/MitoHiFi/src/:/opt/MitoFinder/:/opt/minimap2-2.24_x64-linux/:${PATH}

--- a/environment/code/Dockerfile
+++ b/environment/code/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/marcelauliano/mitohifi-base:b3.2.3
+FROM mitohifi-base
 
 COPY . /opt/MitoHiFi
 

--- a/environment/mitohifi_env.yml
+++ b/environment/mitohifi_env.yml
@@ -8,7 +8,7 @@ dependencies:
   - samtools=1.11
   - cd-hit=4.8.1
   - minimap2=2.19
-  - hifiasm=0.19.5
+  - hifiasm=0.25.0
   - mafft=7.520
   - biopython=1.79
   - matplotlib=3.2.2

--- a/src/createCoveragePlot.py
+++ b/src/createCoveragePlot.py
@@ -1,5 +1,5 @@
 """This script builds a plot (`coverage_plot.png`) containing the mean coverage
-depth distribution for the final representative mitogenom and other assembled
+depth distribution for the final representative mitogenome and other assembled
 potential mito contigs. 
 
 """

--- a/src/createCoveragePlot.py
+++ b/src/createCoveragePlot.py
@@ -90,6 +90,10 @@ def map_potential_contigs(in_reads, contigs, threads=1, covMap=20, ont=False):
    #         with open(f) as infile:
    #             outfile.write(infile.read())
     
+    # Override covMap if ONT
+    if ont:
+        covMap = 5
+        
     # map reads against concatenated contigs file
     preset = "map-ont" if ont else "map-pb"
     minimap_cmd = ["minimap2","-t", str(threads),"--secondary=no","-ax", preset, concatenated_contigs] + in_reads
@@ -149,7 +153,11 @@ def map_final_mito(in_reads, threads=1, covMap=20, ont=False):
     except FileNotFoundError:
         sys.exit("""No final_mitogenome.fasta file.
         An error may have occurred when choosing the representative contig.""")
-    
+
+    # Override covMap if ONT
+    if ont:
+        covMap = 5
+        
     # map reads 
     preset = "map-ont" if ont else "map-pb"
     minimap_cmd = ["minimap2", "-t", str(threads), "--secondary=no", "-ax", preset, "final_mitogenome.fasta"] + in_reads

--- a/src/createCoveragePlot.py
+++ b/src/createCoveragePlot.py
@@ -63,7 +63,7 @@ def get_contigs_to_map():
     return contigs_to_map
 
 
-def map_potential_contigs(in_reads, contigs, threads=1, covMap=20): 
+def map_potential_contigs(in_reads, contigs, threads=1, covMap=20, ont=False): 
     """
     Args:
         in_reads (list): reads file to be mapped against contigs
@@ -91,7 +91,8 @@ def map_potential_contigs(in_reads, contigs, threads=1, covMap=20):
    #             outfile.write(infile.read())
     
     # map reads against concatenated contigs file
-    minimap_cmd = ["minimap2", "-t", str(threads), "--secondary=no", "-ax", "map-pb", concatenated_contigs] + in_reads
+    preset = "map-ont" if ont else "map-pb"
+    minimap_cmd = ["minimap2","-t", str(threads),"--secondary=no","-ax", preset, concatenated_contigs] + in_reads
     samtools_cmd = ["samtools", "view", "-@", str(threads), "-b", "-F4", "-F", "0x800", "-q", str(covMap), "-o", "HiFi-vs-potential_contigs.bam"]
     logging.info("Reads mapping:")
     logging.info(" ".join(minimap_cmd) + " | " + " ".join(samtools_cmd))
@@ -132,7 +133,7 @@ def map_potential_contigs(in_reads, contigs, threads=1, covMap=20):
     
     return "HiFi-vs-potential_contigs.sorted.bam"
 
-def map_final_mito(in_reads, threads=1, covMap=20): 
+def map_final_mito(in_reads, threads=1, covMap=20, ont=False): 
     """
     Args:
         in_reads (list): reads file to be mapped against contigs
@@ -150,7 +151,8 @@ def map_final_mito(in_reads, threads=1, covMap=20):
         An error may have occurred when choosing the representative contig.""")
     
     # map reads 
-    minimap_cmd = ["minimap2", "-t", str(threads), "--secondary=no", "-ax", "map-pb", "final_mitogenome.fasta"] + in_reads
+    preset = "map-ont" if ont else "map-pb"
+    minimap_cmd = ["minimap2", "-t", str(threads), "--secondary=no", "-ax", preset, "final_mitogenome.fasta"] + in_reads
     samtools_cmd = ["samtools", "view", "-@", str(threads), "-b", "-F4", "-F", "0x800", "-q", str(covMap), "-o", "HiFi-vs-final_mitogenome.bam"]
     logging.info("Reads mapping:")
     logging.info(" ".join(minimap_cmd) + " | " + " ".join(samtools_cmd))

--- a/src/createCoveragePlot.py
+++ b/src/createCoveragePlot.py
@@ -15,6 +15,7 @@ import plot_coverage
 import plot_coverage_final_mito
 import PIL
 import numpy as np
+import matplotlib.pyplot as plt
 
 def get_contigs_headers(in_fasta):
     """
@@ -96,6 +97,8 @@ def map_potential_contigs(in_reads, contigs, threads=1, covMap=20, ont=False):
         
     # map reads against concatenated contigs file
     preset = "map-ont" if ont else "map-pb"
+    if isinstance(in_reads, str):
+        in_reads = [in_reads]
     minimap_cmd = ["minimap2","-t", str(threads),"--secondary=no","-ax", preset, concatenated_contigs] + in_reads
     samtools_cmd = ["samtools", "view", "-@", str(threads), "-b", "-F4", "-F", "0x800", "-q", str(covMap), "-o", "HiFi-vs-potential_contigs.bam"]
     logging.info("Reads mapping:")
@@ -160,6 +163,8 @@ def map_final_mito(in_reads, threads=1, covMap=20, ont=False):
         
     # map reads 
     preset = "map-ont" if ont else "map-pb"
+    if isinstance(in_reads, str):
+        in_reads = [in_reads]
     minimap_cmd = ["minimap2", "-t", str(threads), "--secondary=no", "-ax", preset, "final_mitogenome.fasta"] + in_reads
     samtools_cmd = ["samtools", "view", "-@", str(threads), "-b", "-F4", "-F", "0x800", "-q", str(covMap), "-o", "HiFi-vs-final_mitogenome.bam"]
     logging.info("Reads mapping:")
@@ -262,41 +267,47 @@ def merge_images(img_list, out_file):
 
 def create_coverage_plot(mapped_contigs, winSize, repr_contig, is_final_mito=False):
 
-    #print("create_coverage_plot function started:") #debug
     coverage_plots = []
+
     for contig_id in mapped_contigs:
         if is_final_mito:
             genome_filename = plot_coverage_final_mito.make_genome_file(contig_id)
         else:
             genome_filename = plot_coverage.make_genome_file(contig_id)
-        #print(f"genome_filename: {genome_filename}") #debug
+
         genome_windows_filename = plot_coverage.make_genome_windows(genome_filename, winSize)
-        #print(f"genome_windows_filename: {genome_windows_filename}") #debug
+
         if is_final_mito:
             windows_depth_filename = plot_coverage_final_mito.get_windows_depth(genome_windows_filename, "HiFi-vs-final_mitogenome.bam")
         else:
             windows_depth_filename = plot_coverage.get_windows_depth(genome_windows_filename, f"{contig_id}.bam")
-        #print(f"filename: {windows_depth_filename}") #debug
+
         if is_final_mito:
             coverage_plot_filename = plot_coverage_final_mito.plot_coverage("final_mitogenome", windows_depth_filename, winSize, isFinalMito=True)
-            return "final_mitogenome.coverage.png" 
+
+            # 🔴 CLOSE FIGURE
+            plt.close('all')
+            return "final_mitogenome.coverage.png"
+
         else:
             if contig_id == repr_contig:
                 coverage_plot_filename = plot_coverage.plot_coverage(contig_id, windows_depth_filename, winSize, isFinalMito=True)
             else:
                 coverage_plot_filename = plot_coverage.plot_coverage(contig_id, windows_depth_filename, winSize)
-        #print(f"coverage_plot_filename: {coverage_plot_filename}") #debug
+
         coverage_plots.append(coverage_plot_filename)
 
-        #print(f"coverage_plots: {coverage_plots}")
-        
-        ### potential identation problem
-        merge_images(coverage_plots, "coverage_plot.png")
-        try:
-            with open("coverage_plot.png", "r") as f:
-                pass
-        except FileNotFoundError:
-           sys.exit("coverage_plot.png file not found.") 
+        # 🔴 CRITICAL: close figure after each iteration
+        plt.close('all')
+
+    # ✅ MERGE ONLY ONCE
+    merge_images(coverage_plots, "coverage_plot.png")
+
+    try:
+        with open("coverage_plot.png", "r") as f:
+            pass
+    except FileNotFoundError:
+        sys.exit("coverage_plot.png file not found.")
 
     return "coverage_plot.png"
 

--- a/src/fetch.py
+++ b/src/fetch.py
@@ -9,20 +9,47 @@ the potential mito contigs.
 from Bio import SeqIO
 import os 
 
-def get_num_seqs(in_fasta):
-    """Gets the number of sequences in a FASTA file.
-     
-    Args:
-        in_fasta (str): input FASTA file 
-    
-    Returns: 
-        int: number of sequences in FASTA file
+#def get_num_seqs(in_fasta):
+#    """Gets the number of sequences in a FASTA file.
+#     
+#    Args:
+#        in_fasta (str): input FASTA file 
+#    
+#    Returns: 
+#        int: number of sequences in FASTA file
+#    """
+#
+#    c = 0
+#    for rec in SeqIO.parse(in_fasta, "fasta"):
+#        c += 1
+#    return c
+
+def get_num_seqs(file_path):
+    """
+    Count number of sequences in FASTA or FASTQ file.
     """
 
-    c = 0
-    for rec in SeqIO.parse(in_fasta, "fasta"):
-        c += 1
-    return c
+    count = 0
+    with open(file_path) as f:
+        first_char = f.read(1)
+        f.seek(0)
+
+        # FASTA
+        if first_char == ">":
+            for line in f:
+                if line.startswith(">"):
+                    count += 1
+
+        # FASTQ
+        elif first_char == "@":
+            for i, line in enumerate(f):
+                pass
+            count = (i + 1) // 4
+
+        else:
+            raise ValueError("Unknown sequence format")
+
+    return count
 
 def get_ref_tRNA():
     """Defines the reference tRNA to be used for rotating contigs.   
@@ -47,3 +74,4 @@ def get_ref_tRNA():
     else:
         reference_tRNA = max(tRNAs, key=tRNAs.get)
     return reference_tRNA
+

--- a/src/filter_hifiasm_fasta.py
+++ b/src/filter_hifiasm_fasta.py
@@ -1,0 +1,40 @@
+"""
+Filter hifiasm contigs by minimum length.
+
+Used to reduce the number of contigs passed to downstream steps
+(e.g., BLAST, MITOS2, MitoFinder).
+"""
+
+import logging
+from Bio import SeqIO
+
+
+def filter_contigs_by_length(in_fasta, out_fasta, min_len):
+    """
+    Filters contigs from a FASTA file based on minimum length.
+
+    Args:
+        in_fasta (str): input FASTA file
+        out_fasta (str): output FASTA file
+        min_len (int): minimum contig length
+
+    Returns:
+        str: output FASTA filename
+    """
+
+    kept = 0
+    total = 0
+
+    with open(out_fasta, "w") as out_handle:
+        for record in SeqIO.parse(in_fasta, "fasta"):
+            total += 1
+            if len(record.seq) >= min_len:
+                SeqIO.write(record, out_handle, "fasta")
+                kept += 1
+
+    logging.info(f"[filter_hifiasm] Kept {kept}/{total} contigs >= {min_len} bp")
+
+    if kept == 0:
+        logging.warning("[filter_hifiasm] No contigs passed the filter!")
+
+    return out_fasta

--- a/src/getGenesList.py
+++ b/src/getGenesList.py
@@ -22,7 +22,10 @@ def get_genes_list(in_annotation, format="genbank"):
                     genes.append(feat.qualifiers['product'][0])
                     #genes.append([feat.qualifiers['product'], feat.location])
                 elif feat.type == "CDS":
-                    genes.append(feat.qualifiers['gene'][0])
+                    genes.append(feat.qualifiers['product'][0])
+                    name_replacement = {"NADH dehydrogenase subunit 6": "ND6", "NADH dehydrogenase subunit 4L": "ND4L", "12S ribosomal RNA": "s-rRNA", "NADH dehydrogenase subunit 1": "ND1", "ATP synthase F0 subunit 6": "ATP6", "NADH dehydrogenase subunit 2": "ND2", "cytochrome b": "CYTB", "cytochrome c oxidase subunit III": "COIII", "NADH dehydrogenase subunit 4": "ND4", "cytochrome c oxidase subunit I": "COI", "cytochrome c oxidase subunit II": "COII", "16S ribosomal RNA": "l-rRNA", "NADH dehydrogenase subunit 3": "ND3", "NADH dehydrogenase subunit 5": "ND5"}
+                    genes = [gene if gene not in name_replacement else name_replacement[gene] for gene in genes]
+                    #genes.append(feat.qualifiers['gene'][0])
                     #genes.append([feat.qualifiers['gene'], feat.location])
     
     elif format == "gff":

--- a/src/getGenesList.py
+++ b/src/getGenesList.py
@@ -16,17 +16,34 @@ def get_genes_list(in_annotation, format="genbank"):
     genes = []
     
     if format == "genbank":
+        name_replacement = {
+            # long names
+            "NADH dehydrogenase subunit 6": "ND6", "NADH dehydrogenase subunit 4L": "ND4L", "12S ribosomal RNA": "s-rRNA", "NADH dehydrogenase subunit 1": "ND1", "ATP synthase F0 subunit 6": "ATP6", "NADH dehydrogenase subunit 2": "ND2", "cytochrome b": "CYTB", "cytochrome c oxidase subunit III": "COIII", "NADH dehydrogenase subunit 4": "ND4", "cytochrome c oxidase subunit I": "COI", "cytochrome c oxidase subunit II": "COII", "16S ribosomal RNA": "l-rRNA", "NADH dehydrogenase subunit 3": "ND3", "NADH dehydrogenase subunit 5": "ND5",
+
+           # gene symbols (common variants)
+            "cox1": "COI", "COX1": "COI", "cox2": "COII", "cox3": "COIII", "cob": "CYTB", "cytb": "CYTB", "nad1": "ND1", "nad2": "ND2", "nad3": "ND3", "nad4": "ND4", "nad4l": "ND4L", "nad5": "ND5", "nad6": "ND6", "rrnS": "s-rRNA", "rrnL": "l-rRNA"
+        }
+
         for record in SeqIO.parse(in_annotation, format):
             for feat in record.features:
-                if feat.type in ["tRNA", "rRNA"]:
-                    genes.append(feat.qualifiers['product'][0])
-                    #genes.append([feat.qualifiers['product'], feat.location])
-                elif feat.type == "CDS":
-                    genes.append(feat.qualifiers['product'][0])
-                    name_replacement = {"NADH dehydrogenase subunit 6": "ND6", "NADH dehydrogenase subunit 4L": "ND4L", "12S ribosomal RNA": "s-rRNA", "NADH dehydrogenase subunit 1": "ND1", "ATP synthase F0 subunit 6": "ATP6", "NADH dehydrogenase subunit 2": "ND2", "cytochrome b": "CYTB", "cytochrome c oxidase subunit III": "COIII", "NADH dehydrogenase subunit 4": "ND4", "cytochrome c oxidase subunit I": "COI", "cytochrome c oxidase subunit II": "COII", "16S ribosomal RNA": "l-rRNA", "NADH dehydrogenase subunit 3": "ND3", "NADH dehydrogenase subunit 5": "ND5"}
-                    genes = [gene if gene not in name_replacement else name_replacement[gene] for gene in genes]
-                    #genes.append(feat.qualifiers['gene'][0])
-                    #genes.append([feat.qualifiers['gene'], feat.location])
+                if feat.type in ["tRNA", "rRNA", "CDS"]:
+                
+                    # --- SAFE extraction of gene name ---
+                    gene_name = None
+
+                    if 'product' in feat.qualifiers:
+                        gene_name = feat.qualifiers['product'][0]
+                    elif 'gene' in feat.qualifiers:
+                        gene_name = feat.qualifiers['gene'][0]
+                    elif 'locus_tag' in feat.qualifiers:
+                        gene_name = feat.qualifiers['locus_tag'][0]
+                    else:
+                        continue  # skip if nothing usable
+
+                    # --- apply replacement safely ---
+                    gene_name = name_replacement.get(gene_name, gene_name)
+
+                    genes.append(gene_name)
     
     elif format == "gff":
         with open(in_annotation, "r") as f:

--- a/src/mitohifi.py
+++ b/src/mitohifi.py
@@ -37,6 +37,7 @@ from circularizationCheck import circularizationCheck, get_circo_mito
 import alignContigs
 import plot_coverage
 import plot_annotation
+import matplotlib.pyplot as plt
 
 def main():
     
@@ -543,6 +544,7 @@ The pipeline has stopped !! You need to run further scripts to check if you have
         plot_annotation.plot_annotation_mitos("final_mitogenome.gff", "final_mitogenome.annotation.png")
     else:
         plot_annotation.plot_annotation("final_mitogenome.gb", "final_mitogenome.annotation.png")
+    plt.close('all')
     annotation_plots.append("final_mitogenome.annotation.png")
     
     # add other plots following contigs order in `contigs_stats.tsv`
@@ -571,12 +573,14 @@ The pipeline has stopped !! You need to run further scripts to check if you have
                             plot_annotation.plot_annotation_mitos(contig_annotation, contig_annotation_plot)
                         else:
                             plot_annotation.plot_annotation(contig_annotation, contig_annotation_plot)
+                        plt.close('all')
                         annotation_plots.append(contig_annotation_plot)
             else:
                 logging.warning(f"No {contig_annotation} for {contig_id}. Skipping annotation plot for this contig.")
 
     ## concatenating all annotation plots into single final plot
     plot_annotation.merge_images(annotation_plots, "contigs_annotations.png")
+    plt.close('all')
 
     # creating coverage plot (v02)
     if args.r:

--- a/src/mitohifi.py
+++ b/src/mitohifi.py
@@ -587,7 +587,7 @@ The pipeline has stopped !! You need to run further scripts to check if you have
         contigs_to_map = get_contigs_to_map()
         logging.info(f"contigs_to_map: {contigs_to_map}") 
         logging.info(f"{step}.1 Mapping HiFi (filtered) reads against potential contigs:")
-        contigs_mapping = map_potential_contigs(["gbk.HiFiMapped.bam.fasta"], contigs_to_map, args.t, args.covMap)
+        contigs_mapping = map_potential_contigs(["gbk.HiFiMapped.bam.fasta"], contigs_to_map, args.t, args.covMap, ont=args.ont)
         logging.info(f"HiFi reads mapping done. Output file: {contigs_mapping}")
         contigs_headers = get_contigs_headers("all_potential_contigs.fa")
         mapped_contigs = split_mapping_by_contig(contigs_mapping, contigs_headers, threads=args.t)
@@ -603,7 +603,7 @@ The pipeline has stopped !! You need to run further scripts to check if you have
         step += 1
         logging.info(f"{step}. Building coverage distribution for final mitogenome")
         logging.info(f"{step}.1 Mapping HiFi (filtered) reads against final_mitogenome.fasta:")
-        mapping_filename = map_final_mito(["gbk.HiFiMapped.bam.fasta"], args.t, args.covMap)
+        mapping_filename = map_final_mito(["gbk.HiFiMapped.bam.fasta"], args.t, args.covMap, ont=args.ont)
         logging.info(f"HiFi reads mapping done. Output file: {mapping_filename}")
         logging.info(f"{step}.2 Creating coverage plot...")
         coverage_plot_filename = create_coverage_plot([repr_contig_id], args.winSize, repr_contig=repr_contig_id, is_final_mito=True)

--- a/src/mitohifi.py
+++ b/src/mitohifi.py
@@ -40,7 +40,7 @@ import plot_annotation
 
 def main():
     
-    __version__ = '3.2.1'
+    __version__ = '3.2.4beta'
     start_time = time.time()
 
     parser = argparse.ArgumentParser(prog='MitoHiFi')
@@ -148,19 +148,19 @@ def main():
 
         logging.info("3. Now let's run hifiasm to assemble the mapped and filtered reads!")
         
-        hifiasm_cmd = ["hifiasm", "--primary", "-t", str(args.t), "-f", str(args.m), 
-                    "-o", "gbk.HiFiMapped.bam.filtered.assembled",
-                    "gbk.HiFiMapped.bam.filtered.fasta"]
+#        hifiasm_cmd = ["hifiasm", "--primary", "-t", str(args.t), "-f", str(args.m), 
+#                    "-o", "gbk.HiFiMapped.bam.filtered.assembled",
+#                    "gbk.HiFiMapped.bam.filtered.fasta"]
         
 #### THE HIFIASM_CMD CAN BE REPLACED WITH THE COMMANDS BELOW WHEN HIFIASM WITHIN MITOHIFI IS UPDATED TO THE NEWEST VERSION ####        
-#        hifiasm_cmd = ["hifiasm"]
+        hifiasm_cmd = ["hifiasm"]
 
         # Add ONT mode if requested
-#        if args.ont:
-#            hifiasm_cmd.append("--ont")
+        if args.ont:
+            hifiasm_cmd.append("--ont")
 
-#        hifiasm_cmd.extend(["--primary", "-t", str(args.t), "-f", str(args.m), "-o", 
-#            "gbk.HiFiMapped.bam.filtered.assembled", "gbk.HiFiMapped.bam.filtered.fasta"])
+        hifiasm_cmd.extend(["--primary", "-t", str(args.t), "-f", str(args.m), "-o", 
+            "gbk.HiFiMapped.bam.filtered.assembled", "gbk.HiFiMapped.bam.filtered.fasta"])
         
         logging.info(" ".join(hifiasm_cmd))
         with open("hifiasm.log", "w") as hifiasm_log_f:

--- a/src/mitohifi.py
+++ b/src/mitohifi.py
@@ -122,29 +122,66 @@ def main():
             f.close()
 
         logging.info("2. Now we filter out any mapped reads that are larger than the reference mitogenome to avoid NUMTS")
-        bam2fasta_cmd = ["samtools", "fasta", "reads.HiFiMapped.bam"]
-        logging.info("2.1 First we convert the mapped reads from BAM to FASTA format:")
-        logging.info(" ".join(bam2fasta_cmd) + " > gbk.HiFiMapped.bam.fasta")
-        mapped_fasta_f = open("gbk.HiFiMapped.bam.fasta", "w")
-        subprocess.run(bam2fasta_cmd, stdout=mapped_fasta_f, stderr=subprocess.DEVNULL)
-        before_filter = fetch.get_num_seqs("gbk.HiFiMapped.bam.fasta")
-        logging.info(f"Total number of mapped reads: {before_filter}")
-        
-        max_read_len = round(args.max_read_len * rel_mito_len)
-        logging.info(f"2.2 Then we filter reads that are larger than {max_read_len} bp")
-        filterfasta.filterFasta(minLength=max_read_len, neg=True, inStream="gbk.HiFiMapped.bam.fasta",
-                                outPath="gbk.HiFiMapped.bam.filtered.fasta", log=False)
-        
-        try:
-            f = open("gbk.HiFiMapped.bam.filtered.fasta")
-        except FileNotFoundError:
-            sys.exit("""No gbk.HiFiMapped.bam.filtered.fasta file.
-            An error may have occurred when filtering reads larger than the reference mitogenome""")
-        finally:
-            f.close()
+        if args.ont:
+            # -----------------------------
+            # ONT workflow (FASTQ)
+            # -----------------------------
+            bam2fastq_cmd = ["samtools", "fastq", "reads.HiFiMapped.bam"]
+            logging.info("2.1 First we convert the mapped reads from BAM to FASTQ format:")
+            logging.info(" ".join(bam2fastq_cmd) + " > gbk.HiFiMapped.bam.fastq")
+            mapped_fastq_f = open("gbk.HiFiMapped.bam.fastq", "w")
+            subprocess.run(bam2fastq_cmd, stdout=mapped_fastq_f, stderr=subprocess.DEVNULL)
+            before_filter = fetch.get_num_seqs("gbk.HiFiMapped.bam.fastq")
+            logging.info(f"Total number of mapped reads: {before_filter}")
 
-        after_filter = fetch.get_num_seqs("gbk.HiFiMapped.bam.filtered.fasta")
-        logging.info(f"Number of filtered reads: {after_filter}")
+            max_read_len = round(args.max_read_len * rel_mito_len)
+            logging.info(f"2.2 Then we filter reads that are larger than {max_read_len} bp (FASTQ)")
+
+            with open("gbk.HiFiMapped.bam.fastq") as infile, \
+                 open("gbk.HiFiMapped.bam.filtered.fastq", "w") as outfile:
+
+                for record in SeqIO.parse(infile, "fastq"):
+                    if len(record.seq) <= max_read_len:
+                        SeqIO.write(record, outfile, "fastq")
+
+            try:
+                f = open("gbk.HiFiMapped.bam.filtered.fastq")
+            except FileNotFoundError:
+                sys.exit("""No gbk.HiFiMapped.bam.filtered.fastq file.
+                An error may have occurred when filtering reads larger than the reference mitogenome""")
+            finally:
+                f.close()
+
+            after_filter = fetch.get_num_seqs("gbk.HiFiMapped.bam.filtered.fastq")
+            logging.info(f"Number of filtered reads: {after_filter}")
+        
+            else:
+            # -----------------------------
+            # Original HiFi workflow (FASTA)
+            # -----------------------------
+            bam2fasta_cmd = ["samtools", "fasta", "reads.HiFiMapped.bam"]
+            logging.info("2.1 First we convert the mapped reads from BAM to FASTA format:")
+            logging.info(" ".join(bam2fasta_cmd) + " > gbk.HiFiMapped.bam.fasta")
+            mapped_fasta_f = open("gbk.HiFiMapped.bam.fasta", "w")
+            subprocess.run(bam2fasta_cmd, stdout=mapped_fasta_f, stderr=subprocess.DEVNULL)
+            before_filter = fetch.get_num_seqs("gbk.HiFiMapped.bam.fasta")
+            logging.info(f"Total number of mapped reads: {before_filter}")
+
+            max_read_len = round(args.max_read_len * rel_mito_len)
+            logging.info(f"2.2 Then we filter reads that are larger than {max_read_len} bp")
+            filterfasta.filterFasta(minLength=max_read_len, neg=True, inStream="gbk.HiFiMapped.bam.fasta",
+                                    outPath="gbk.HiFiMapped.bam.filtered.fasta", log=False)
+
+            try:
+                f = open("gbk.HiFiMapped.bam.filtered.fasta")
+            except FileNotFoundError:
+                sys.exit("""No gbk.HiFiMapped.bam.filtered.fasta file.
+                An error may have occurred when filtering reads larger than the reference mitogenome""")
+            finally:
+                f.close()
+
+            after_filter = fetch.get_num_seqs("gbk.HiFiMapped.bam.filtered.fasta")
+            logging.info(f"Number of filtered reads: {after_filter}")
 
         logging.info("3. Now let's run hifiasm to assemble the mapped and filtered reads!")
         

--- a/src/mitohifi.py
+++ b/src/mitohifi.py
@@ -155,7 +155,7 @@ def main():
             after_filter = fetch.get_num_seqs("gbk.HiFiMapped.bam.filtered.fastq")
             logging.info(f"Number of filtered reads: {after_filter}")
         
-            else:
+        else:
             # -----------------------------
             # Original HiFi workflow (FASTA)
             # -----------------------------

--- a/src/mitohifi.py
+++ b/src/mitohifi.py
@@ -21,6 +21,7 @@ from createCoveragePlot import map_potential_contigs, map_final_mito, get_contig
 import fetch
 import fetch_mitos
 import filterfasta
+import filter_hifiasm_fasta
 import findFrameShifts
 import fixContigHeaders
 import functools
@@ -59,6 +60,7 @@ def main():
     optional.add_argument("-a", help="-a: Choose between animal (default) or plant", default="animal", choices=["animal", "plant", "fungi"])
     optional.add_argument("-p", help="-p: Percentage of query in the blast match with close-related mito", type=int, default=50, metavar='<PERC>')
     optional.add_argument("-m", help="-m: Number of bits for HiFiasm bloom filter [it maps to -f in HiFiasm] (default = 0)", type=int, default=0, metavar='<BLOOM FILTER>')
+    optional.add_argument("--min-contig-len", help="Minimum contig length to retain after hifiasm assembly (default = 0)", type=int, default=0)
     optional.add_argument("--max-read-len", help="Maximum lenght of read relative to related mito (default = 1.0x related mito length)", type=float, default=1.0)
     optional.add_argument("--mitos", help="Use MITOS2 for annotation (opposed to default MitoFinder", action="store_true")
     optional.add_argument('--circular-size', help='Size to consider when checking for circularization', type=int, default=220)
@@ -230,6 +232,14 @@ def main():
             subprocess.run(["cat", "gbk.HiFiMapped.bam.filtered.assembled.p_ctg.fa", "gbk.HiFiMapped.bam.filtered.assembled.a_ctg.fa"], stdout=hifiasm_f)
         
         contigs = "hifiasm.contigs.fasta"
+        
+        # --- NEW: optional contig filtering ---
+        if args.min_contig_len and args.min_contig_len > 0:
+            logging.info(f"Filtering contigs shorter than {args.min_contig_len} bp")
+            
+            filtered_contigs = "hifiasm.contigs.filtered.fasta"
+            
+            contigs = filter_hifiasm_fasta.filter_contigs_by_length(contigs, filtered_contigs, args.min_contig_len)
     
     else:
         logging.info("Running MitoHifi pipeline in contigs mode...")

--- a/src/mitohifi.py
+++ b/src/mitohifi.py
@@ -54,6 +54,7 @@ def main():
     required.add_argument("-g", help= "-k: Close-related species Mitogenome in genebank format", required = "True", metavar='<relatedMito>.gbk')
     required.add_argument("-t", help= "-t: Number of threads for (i) hifiasm and (ii) the blast search", required = "True", type=int, metavar='<THREADS>')    
     optional.add_argument("-d", help="-d: debug mode to output additional info on log", action="store_true")    
+    optional.add_argument("--ont", help="Use Oxford Nanopore (ONT) settings instead of PacBio HiFi for minimap2 and hifiasm", action="store_true")
     optional.add_argument("-a", help="-a: Choose between animal (default) or plant", default="animal", choices=["animal", "plant", "fungi"])
     optional.add_argument("-p", help="-p: Percentage of query in the blast match with close-related mito", type=int, default=50, metavar='<PERC>')
     optional.add_argument("-m", help="-m: Number of bits for HiFiasm bloom filter [it maps to -f in HiFiasm] (default = 0)", type=int, default=0, metavar='<BLOOM FILTER>')
@@ -99,7 +100,11 @@ def main():
     if args.r:
         logging.info("Running MitoHifi pipeline in reads mode...")
         logging.info("1. First we map your Pacbio HiFi reads to the close-related mitogenome")
-        minimap_cmd = ["minimap2", "-t", str(args.t), "--secondary=no", "-ax", "map-hifi", args.f] + shlex.split(args.r) 
+        # Choose minimap2 preset depending on sequencing technology
+        minimap_preset = "map-hifi"
+        if args.ont:
+            minimap_preset = "map-ont"
+        minimap_cmd = ["minimap2", "-t", str(args.t), "--secondary=no", "-ax", minimap_preset, args.f] + shlex.split(args.r)
         samtools_cmd = ["samtools", "view", "-@", str(args.t), "-b", "-F4", "-F", "0x800", "-o", "reads.HiFiMapped.bam"] 
         logging.info(" ".join(minimap_cmd) + " | " + " ".join(samtools_cmd))        
         minimap = subprocess.Popen(minimap_cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
@@ -146,7 +151,17 @@ def main():
         hifiasm_cmd = ["hifiasm", "--primary", "-t", str(args.t), "-f", str(args.m), 
                     "-o", "gbk.HiFiMapped.bam.filtered.assembled",
                     "gbk.HiFiMapped.bam.filtered.fasta"]
+        
+#### THE HIFIASM_CMD CAN BE REPLACED WITH THE COMMANDS BELOW WHEN HIFIASM WITHIN MITOHIFI IS UPDATED TO THE NEWEST VERSION ####        
+#        hifiasm_cmd = ["hifiasm"]
 
+        # Add ONT mode if requested
+#        if args.ont:
+#            hifiasm_cmd.append("--ont")
+
+#        hifiasm_cmd.extend(["--primary", "-t", str(args.t), "-f", str(args.m), "-o", 
+#            "gbk.HiFiMapped.bam.filtered.assembled", "gbk.HiFiMapped.bam.filtered.fasta"])
+        
         logging.info(" ".join(hifiasm_cmd))
         with open("hifiasm.log", "w") as hifiasm_log_f:
             subprocess.run(hifiasm_cmd, stderr=subprocess.STDOUT, stdout=hifiasm_log_f)       

--- a/src/mitohifi.py
+++ b/src/mitohifi.py
@@ -48,7 +48,7 @@ def main():
     required = parser.add_argument_group('required arguments')
     optional = parser.add_argument_group('optional arguments')
     mutually_exclusive_group = required.add_mutually_exclusive_group(required=True)    
-    mutually_exclusive_group.add_argument("-r", help= "-r: Pacbio Hifi Reads from your species", metavar='<reads>.fasta')
+    mutually_exclusive_group.add_argument("-r", help= "-r: Pacbio Hifi or ONT Reads from your species", metavar='<reads>.fasta')
     mutually_exclusive_group.add_argument("-c", help= "-c: Assembled fasta contigs/scaffolds to be searched to find mitogenome", metavar='<contigs>.fasta')
     required.add_argument("-f", help= "-f: Close-related Mitogenome is fasta format", required = "True", metavar='<relatedMito>.fasta')
     required.add_argument("-g", help= "-k: Close-related species Mitogenome in genebank format", required = "True", metavar='<relatedMito>.gbk')
@@ -99,7 +99,7 @@ def main():
     # If input are reads, map them to the related mitogenome and assemble the mapped ones
     if args.r:
         logging.info("Running MitoHifi pipeline in reads mode...")
-        logging.info("1. First we map your Pacbio HiFi reads to the close-related mitogenome")
+        logging.info("1. First we map your Pacbio HiFi or ONT reads to the close-related mitogenome")
         # Choose minimap2 preset depending on sequencing technology
         minimap_preset = "map-hifi"
         if args.ont:

--- a/src/mitohifi.py
+++ b/src/mitohifi.py
@@ -195,9 +195,12 @@ def main():
         # Add ONT mode if requested
         if args.ont:
             hifiasm_cmd.append("--ont")
+            input_reads = "gbk.HiFiMapped.bam.filtered.fastq"
+        else:
+            input_reads = "gbk.HiFiMapped.bam.filtered.fasta"
 
         hifiasm_cmd.extend(["--primary", "-t", str(args.t), "-f", str(args.m), "-o", 
-            "gbk.HiFiMapped.bam.filtered.assembled", "gbk.HiFiMapped.bam.filtered.fasta"])
+            "gbk.HiFiMapped.bam.filtered.assembled", input_reads])
         
         logging.info(" ".join(hifiasm_cmd))
         with open("hifiasm.log", "w") as hifiasm_log_f:

--- a/src/mitohifi.py
+++ b/src/mitohifi.py
@@ -584,10 +584,11 @@ The pipeline has stopped !! You need to run further scripts to check if you have
         logging.info(f"{step}. Building coverage distribution for each potential contig")
         
         #reads = shlex.split(args.r)
+        reads_file = "gbk.HiFiMapped.bam.filtered.fastq" if args.ont else "gbk.HiFiMapped.bam.filtered.fasta"
         contigs_to_map = get_contigs_to_map()
         logging.info(f"contigs_to_map: {contigs_to_map}") 
         logging.info(f"{step}.1 Mapping HiFi (filtered) reads against potential contigs:")
-        contigs_mapping = map_potential_contigs(["gbk.HiFiMapped.bam.fasta"], contigs_to_map, args.t, args.covMap, ont=args.ont)
+        contigs_mapping = map_potential_contigs(reads_file, contigs_to_map, args.t, args.covMap, ont=args.ont)
         logging.info(f"HiFi reads mapping done. Output file: {contigs_mapping}")
         contigs_headers = get_contigs_headers("all_potential_contigs.fa")
         mapped_contigs = split_mapping_by_contig(contigs_mapping, contigs_headers, threads=args.t)
@@ -603,7 +604,7 @@ The pipeline has stopped !! You need to run further scripts to check if you have
         step += 1
         logging.info(f"{step}. Building coverage distribution for final mitogenome")
         logging.info(f"{step}.1 Mapping HiFi (filtered) reads against final_mitogenome.fasta:")
-        mapping_filename = map_final_mito(["gbk.HiFiMapped.bam.fasta"], args.t, args.covMap, ont=args.ont)
+        mapping_filename = map_final_mito(reads_file, args.t, args.covMap, ont=args.ont)
         logging.info(f"HiFi reads mapping done. Output file: {mapping_filename}")
         logging.info(f"{step}.2 Creating coverage plot...")
         coverage_plot_filename = create_coverage_plot([repr_contig_id], args.winSize, repr_contig=repr_contig_id, is_final_mito=True)


### PR DESCRIPTION
- Added `--ont` options to switch to ONT compatible settings
- Added code for running minimap2 with ONT settings
- Made sure that minimap2 output was transformed into FASTQ rather than FASTA when `--ont` is added to make sure hifiasm run with ONT settings is possible
- Update hifiasm version to v0.25.0
- Added code for running hifiasm with ONT settings using the FASTQ output
- Adjusted Dockerfiles in order to make deployment possible -> this could be transformed back, but will need to be update in order to maintain an updated hifiasm version -> the older version isn't compatible with ONT reads
- Added brief instructions on how to create a singularity container from this ONT compatible version

Hope this version will be integrated, as it provides more versatility of the tool and will improve performance for ONT users